### PR TITLE
Kr nkpr 133 update char count style

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # ACF Input Counter
 
+*Fork of: [https://github.com/Hube2/acf-input-counter](https://github.com/Hube2/acf-input-counter)*
+
 Supports ACF 5
 
 Adds a counter to all text and textarea fields with character limits.
@@ -8,7 +10,7 @@ This is a simple plugin that will add a counter below all ACF text and text area
 characters have been added and what the limit is. The display will look something like this:
 
 ```
-chars: 25 of 55
+Character Count: 25 / 55
 ```
 
 This plugin will not work in ACF 4 for 2 reasons:

--- a/acf-counter.css
+++ b/acf-counter.css
@@ -1,6 +1,8 @@
 .acf-field .char-count {
-    display:        inline-block;
-    font-weight:    bold;
-    font-style:     italic;
-    margin-top:     .5em;
+  display: block;
+  margin: 0;
+  padding: 0;
+  font-size: 11px;
+  font-style: italic;
+  color: #666;
 }

--- a/acf-input-counter.php
+++ b/acf-input-counter.php
@@ -110,7 +110,7 @@
 				return;
 			}
 			$display = sprintf(
-				__('chars: %1$s of %2$s', 'acf-counter'),
+				__('Character Count: %1$s / %2$s', 'acf-counter'),
 				'%%len%%',
 				'%%max%%'
 			);
@@ -184,4 +184,3 @@
 				<p><a href="https://www.paypal.com/cgi-bin/webscr?cmd=_donations&business=hube02%40earthlink%2enet&lc=US&item_name=Donation%20for%20WP%20Plugins%20I%20Use&no_note=0&cn=Add%20special%20instructions%20to%20the%20seller%3a&no_shipping=1&currency_code=USD&bn=PP%2dDonationsBF%3abtn_donateCC_LG%2egif%3aNonHosted" target="_blank">Please consider making a small donation.</a></p><?php
 		}
 	} // end if !function_exists
-

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "type": "wordpress-plugin",
     "license": "GPL-3.0",
     "keywords": ["wordpress", "plugin", "acf"],
-    "homepage": "https://github.com/Hube2/acf-input-counter",
+    "homepage": "https://github.com/planetargon/acf-input-counter",
     "require": {
         "composer/installers": "^1.5.0"
     }


### PR DESCRIPTION
I wanted to make a few changes to the style of this plugin to make it more cohesive with the Wordpress environment using the fork.

Changes Proposed
* CSS to match other ACF text
* Display text to read "Character Counter XX / XX" instead of "chars: XX / XX"
* Update composer.json and ReadMe to point to Planet Argon fork